### PR TITLE
Deprecated api to send request to support

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -74,6 +74,7 @@
             }
           }
         },
+        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]

--- a/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationService.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.notification_manager.core;
 import it.pagopa.selfcare.notification_manager.core.model.MessageRequest;
 
 public interface NotificationService {
+    @Deprecated
     void sendMessageToCustomerCare(MessageRequest messageRequest);
 
     void sendMessageToUser(MessageRequest messageRequest);

--- a/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationServiceImpl.java
@@ -42,6 +42,7 @@ public class NotificationServiceImpl implements NotificationService {
         this.userMailSubjectPrefix = userMailSubjectPrefix;
     }
 
+    @Deprecated
     @SneakyThrows
     @Override
     public void sendMessageToCustomerCare(MessageRequest messageRequest) {

--- a/web/src/main/java/it/pagopa/selfcare/notification_manager/web/controller/NotificationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/notification_manager/web/controller/NotificationController.java
@@ -28,6 +28,10 @@ public class NotificationController {
         this.notificationService = notificationService;
     }
 
+    /**
+     * @deprecated
+     */
+    @Deprecated(since = "1.0-SNAPSHOT")
     @PostMapping(value = "/customer-care")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiOperation(value = "", notes = "${swagger.notification_manager.notifications.api.sendNotificationToCustomerCare}")


### PR DESCRIPTION
#### List of Changes

Deprecated api that send request to support office.

#### Motivation and Context

This change is linked to zendesk integration, so this api is not used anymore.

