### PR TITLE
Fix senderEmail to use request email and not spid one

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import java.util.Optional;
 
@@ -59,16 +60,15 @@ public class NotificationServiceImpl implements NotificationService {
         mail.setTo(customerCareMail);
         mail.setSubject(String.format("%s%s %s", customerCareMailSubjectPrefix, messageRequest.getSubject(), principal.getFiscalCode()));
         mail.setContent(messageRequest.getContent());
-        if (principal.getEmail() == null) {
-            if (messageRequest.getSenderEmail() != null) {
-                mail.setReplyTo(Optional.of(messageRequest.getSenderEmail()));
+        if (messageRequest.getSenderEmail() != null) {
+            mail.setReplyTo(Optional.of(messageRequest.getSenderEmail()));
+        } else {
+            if(StringUtils.hasText(principal.getEmail())) {
+                mail.setReplyTo(Optional.of(principal.getEmail()));
             } else {
                 throw new MessageRequestException("Missing replyTo address");
             }
-        } else {
-            mail.setReplyTo(Optional.of(principal.getEmail()));
         }
-
         notificationService.sendMessage(mail);
         log.trace("sendMessageToCustomerCare end");
 


### PR DESCRIPTION
#### List of Changes

I have fixed the service that send email in order to use the parameter from request and not from spid object.

#### Motivation and Context

This change was necessary to fix the bug opened from assistance support layer.

#### How Has This Been Tested?

I have run microservice locally and tested the api /custom-care using as senderEmail my personal email. 
