### PR TITLE
[SELC-3740] Feat: new API for send notification to multiple receiver

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -134,6 +134,61 @@
           "bearerAuth" : [ "global" ]
         } ]
       }
+    },
+    "/notifications/v1/users" : {
+      "post" : {
+        "tags" : [ "notification-manager" ],
+        "summary" : "sendNotificationToUsers",
+        "description" : "Service that sends the notification to multiple receiver",
+        "operationId" : "sendNotificationToUsersUsingPOST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateMessageToUsersDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
     }
   },
   "components" : {
@@ -169,6 +224,28 @@
           "receiverEmail" : {
             "type" : "string",
             "description" : "Notification message receiver email"
+          },
+          "subject" : {
+            "type" : "string",
+            "description" : "Notification message subject"
+          }
+        }
+      },
+      "CreateMessageToUsersDto" : {
+        "title" : "CreateMessageToUsersDto",
+        "required" : [ "content", "receiverEmails", "subject" ],
+        "type" : "object",
+        "properties" : {
+          "content" : {
+            "type" : "string",
+            "description" : "Notification message content"
+          },
+          "receiverEmails" : {
+            "type" : "array",
+            "description" : "Notification message receiver email",
+            "items" : {
+              "type" : "string"
+            }
           },
           "subject" : {
             "type" : "string",

--- a/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationService.java
@@ -1,10 +1,13 @@
 package it.pagopa.selfcare.notification_manager.core;
 
 import it.pagopa.selfcare.notification_manager.core.model.MessageRequest;
+import it.pagopa.selfcare.notification_manager.core.model.MultiReceiverMessageRequest;
 
 public interface NotificationService {
     @Deprecated
     void sendMessageToCustomerCare(MessageRequest messageRequest);
 
     void sendMessageToUser(MessageRequest messageRequest);
+
+    void sendMessageToUsers(MultiReceiverMessageRequest messageRequest);
 }

--- a/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/notification_manager/core/NotificationServiceImpl.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.notification_manager.api.NotificationConnector;
 import it.pagopa.selfcare.notification_manager.api.model.MailRequest;
 import it.pagopa.selfcare.notification_manager.core.exception.MessageRequestException;
 import it.pagopa.selfcare.notification_manager.core.model.MessageRequest;
+import it.pagopa.selfcare.notification_manager.core.model.MultiReceiverMessageRequest;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +49,7 @@ public class NotificationServiceImpl implements NotificationService {
     public void sendMessageToCustomerCare(MessageRequest messageRequest) {
         log.trace("sendMessageToCustomerCare start");
         log.debug("sendMessageToCustomerCare messageRequest = {}", messageRequest);
-        Assert.notNull(messageRequest, "Message request must not be null");
+        Assert.notNull(messageRequest, "request must not be null");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Assert.state(authentication != null, "Authentication is required");
         Assert.state(authentication.getPrincipal() instanceof SelfCareUser, "Not SelfCareUSer principal");
@@ -81,16 +82,36 @@ public class NotificationServiceImpl implements NotificationService {
         log.debug("sendMessageToUser messageRequest = {}", messageRequest);
         Assert.notNull(messageRequest, "Message request must not be null");
 
-        MailRequest mail = new MailRequest();
-        mail.setFrom(noReplyMailAddress);
-        mail.setTo(messageRequest.getReceiverEmail());
-        mail.setSubject(userMailSubjectPrefix + messageRequest.getSubject());
-        mail.setContent(messageRequest.getContent());
-        mail.setReplyTo(Optional.empty());
+        MailRequest mail = constructMailRequest(messageRequest.getReceiverEmail(), userMailSubjectPrefix + messageRequest.getSubject(), messageRequest.getContent());
         notificationService.sendMessage(mail);
         log.trace("sendMessageToUser end");
-
     }
 
+    @Override
+    public void sendMessageToUsers(MultiReceiverMessageRequest messageRequest) {
+        log.trace("sendMessageToUsers start");
+        log.debug("sendMessageToUsers messageRequest = {}", messageRequest);
+        Assert.notNull(messageRequest, "Multi receiver Message request must not be null");
 
+        messageRequest.getReceiverEmail().stream()
+                .map(s -> constructMailRequest(s, messageRequest.getSubject(), messageRequest.getContent()))
+                .forEach(this::sendMessage);
+
+        log.trace("sendMessageToUser end");
+    }
+
+    @SneakyThrows
+    private void sendMessage(MailRequest mailRequest) {
+        notificationService.sendMessage(mailRequest);
+    }
+
+    private MailRequest constructMailRequest(String to, String subject, String content) {
+        MailRequest mail = new MailRequest();
+        mail.setFrom(noReplyMailAddress);
+        mail.setTo(to);
+        mail.setSubject(subject);
+        mail.setContent(content);
+        mail.setReplyTo(Optional.empty());
+        return mail;
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/notification_manager/core/model/MultiReceiverMessageRequest.java
+++ b/core/src/main/java/it/pagopa/selfcare/notification_manager/core/model/MultiReceiverMessageRequest.java
@@ -1,0 +1,14 @@
+package it.pagopa.selfcare.notification_manager.core.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MultiReceiverMessageRequest {
+
+    String content;
+    String subject;
+    String senderEmail;
+    List<String> receiverEmail;
+}

--- a/web/src/main/java/it/pagopa/selfcare/notification_manager/web/controller/NotificationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/notification_manager/web/controller/NotificationController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.notification_manager.core.NotificationService;
 import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToCustomerCareDto;
 import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToUserDto;
+import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToUsersDto;
 import it.pagopa.selfcare.notification_manager.web.model.mapper.MessageMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +59,16 @@ public class NotificationController {
         log.debug("sendNotificationToUser createMessageToUserDto = {}", createMessageToUserDto);
         notificationService.sendMessageToUser(MessageMapper.toMessageRequest(createMessageToUserDto));
         log.trace("sendNotificationToUser end");
+    }
 
+    @PostMapping(value = "/users")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "", notes = "${swagger.notification_manager.notifications.api.sendNotificationToUsers}")
+    void sendNotificationToUsers(@RequestBody @Valid CreateMessageToUsersDto createMessageToUsersDto) {
+        log.trace("sendNotificationToUser start");
+        log.debug("sendNotificationToUser createMessageToUserDto = {}", createMessageToUsersDto);
+        notificationService.sendMessageToUsers(MessageMapper.toMessageRequest(createMessageToUsersDto));
+        log.trace("sendNotificationToUser end");
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/notification_manager/web/model/CreateMessageToUsersDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/notification_manager/web/model/CreateMessageToUsersDto.java
@@ -1,0 +1,28 @@
+package it.pagopa.selfcare.notification_manager.web.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Data
+public class CreateMessageToUsersDto {
+
+    @ApiModelProperty(value = "${swagger.notification_manager.model.content}", required = true)
+    @JsonProperty(required = true)
+    @NotBlank
+    String content;
+
+    @ApiModelProperty(value = "${swagger.notification_manager.model.subject}", required = true)
+    @JsonProperty(required = true)
+    @NotBlank
+    String subject;
+
+    @ApiModelProperty(value = "${swagger.notification_manager.model.receiverEmail}", required = true)
+    @JsonProperty(required = true)
+    @NotNull
+    List<String> receiverEmails;
+}

--- a/web/src/main/java/it/pagopa/selfcare/notification_manager/web/model/mapper/MessageMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/notification_manager/web/model/mapper/MessageMapper.java
@@ -1,8 +1,10 @@
 package it.pagopa.selfcare.notification_manager.web.model.mapper;
 
 import it.pagopa.selfcare.notification_manager.core.model.MessageRequest;
+import it.pagopa.selfcare.notification_manager.core.model.MultiReceiverMessageRequest;
 import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToCustomerCareDto;
 import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToUserDto;
+import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToUsersDto;
 
 public class MessageMapper {
 
@@ -24,6 +26,17 @@ public class MessageMapper {
             message.setContent(messageDto.getContent());
             message.setSubject(messageDto.getSubject());
             message.setReceiverEmail(messageDto.getReceiverEmail());
+        }
+        return message;
+    }
+
+    public static MultiReceiverMessageRequest toMessageRequest(CreateMessageToUsersDto messageDto) {
+        MultiReceiverMessageRequest message = null;
+        if (messageDto != null) {
+            message = new MultiReceiverMessageRequest();
+            message.setContent(messageDto.getContent());
+            message.setSubject(messageDto.getSubject());
+            message.setReceiverEmail(messageDto.getReceiverEmails());
         }
         return message;
     }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -3,6 +3,7 @@ swagger.security.schema.bearer.description=A bearer token in the format of a JWS
 swagger.notification_manager.api.description=Notification Manager operations
 swagger.notification_manager.notifications.api.sendNotificationToCustomerCare=Service that sends the notification to the Customer Care
 swagger.notification_manager.notifications.api.sendNotificationToUser=Service that sends the notification to the User
+swagger.notification_manager.notifications.api.sendNotificationToUsers=Service that sends the notification to multiple receiver
 swagger.notification_manager.model.messageRequest=Notification message request body
 swagger.notification_manager.model.content=Notification message content
 swagger.notification_manager.model.subject=Notification message subject

--- a/web/src/test/java/it/pagopa/selfcare/notification_manager/web/model/mapper/MessageMapperTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/notification_manager/web/model/mapper/MessageMapperTest.java
@@ -2,8 +2,10 @@ package it.pagopa.selfcare.notification_manager.web.model.mapper;
 
 import it.pagopa.selfcare.commons.utils.TestUtils;
 import it.pagopa.selfcare.notification_manager.core.model.MessageRequest;
+import it.pagopa.selfcare.notification_manager.core.model.MultiReceiverMessageRequest;
 import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToCustomerCareDto;
 import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToUserDto;
+import it.pagopa.selfcare.notification_manager.web.model.CreateMessageToUsersDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -52,5 +54,17 @@ class MessageMapperTest {
         MessageRequest messageRequest = MessageMapper.toMessageRequest(messageToUserDto);
         //then
         Assertions.assertNull(messageRequest);
+    }
+
+    @Test
+    void toMessageRequestMultipleReceiver(){
+        CreateMessageToUsersDto messageDto = TestUtils.mockInstance(new CreateMessageToUsersDto());
+        //when
+        MultiReceiverMessageRequest messageRequest = MessageMapper.toMessageRequest(messageDto);
+        //then
+        Assertions.assertEquals(messageDto.getContent(), messageRequest.getContent());
+        Assertions.assertEquals(messageDto.getSubject(), messageRequest.getSubject());
+        Assertions.assertEquals(messageDto.getReceiverEmails(), messageRequest.getReceiverEmail());
+        TestUtils.reflectionEqualsByName(messageRequest, messageDto);
     }
 }


### PR DESCRIPTION
#### List of Changes

-  Added API for send notification to multiple receiver

#### Motivation and Context

when a new delegation is created we have to send the email to all the administrators and operators of the pt

#### How Has This Been Tested?

local env

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.